### PR TITLE
FEATURE: Add excluded items list

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -2,7 +2,11 @@
   position: relative;
 }
 
-.list-controls .nav-pills.compact-version > li {
+.list-controls .nav.nav-pills.compact-version li.navigation-toggle {
+  margin-right: 1em;
+}
+
+.list-controls .nav-pills.compact-version > li:not(.external) {
   margin-right: 0;
   font-size: .8706em;
   border: 1px solid var(--primary-medium);

--- a/javascripts/discourse/helpers/internal-or-external.js
+++ b/javascripts/discourse/helpers/internal-or-external.js
@@ -1,0 +1,23 @@
+import { registerUnbound } from "discourse-common/lib/helpers";
+
+registerUnbound("shouldBeExternal", (navItem, selectedItem) => {
+  let externalNavItems = settings.nav_items_to_exclude.split("|");
+
+  if (
+    // check to see if nav item is in excluded list, and that it does 
+    // not equal the currently selected item
+    externalNavItems.indexOf(navItem.name) !== -1 &&
+    navItem.name !== selectedItem.toLowerCase()
+  ) {
+    return true;
+  }
+});
+
+registerUnbound("shouldBeInternal", (navItem, selectedItem) => {
+  let externalNavItems = settings.nav_items_to_exclude.split("|");
+  if (externalNavItems.indexOf(navItem.name) !== -1) {
+    return false;
+  } else {
+    return true;
+  }
+});

--- a/javascripts/discourse/initializers/custom-nav.js
+++ b/javascripts/discourse/initializers/custom-nav.js
@@ -8,6 +8,13 @@ export default apiInitializer("0.8", api => {
     classNameBindings: ["showCompactNav:compact-version"],
     showCompactVersion: alias("showCompactNav"),
     router: service("router"),
+    isMobile: alias("showMobileVersion"),
+
+    @discourseComputed("site.isMobileDevice")
+    showMobileVersion(isMobile) {
+      console.log(isMobile)
+      return isMobile;
+    },
 
     @discourseComputed("site.isMobileDevice", "router.currentRouteName")
     showCompactNav(isMobile, routeName) {

--- a/javascripts/discourse/templates/components/navigation-bar.hbs
+++ b/javascripts/discourse/templates/components/navigation-bar.hbs
@@ -9,13 +9,22 @@
   {{#if expanded}}
     <ul class="drop">
       {{#each navItems as |navItem|}}
-        {{navigation-item content=navItem filterMode=filterMode category=category}}
+        {{#if (shouldBeInternal navItem selectedNavItem.displayName)}}
+          {{navigation-item content=navItem filterMode=filterMode category=category}}
+        {{/if}}
       {{/each}}
       {{#each connectors as |c|}}
         {{plugin-connector connector=c class=c.classNames tagName="li" args=(hash category=category filterMode=filterMode)}}
       {{/each}}
     </ul>
   {{/if}}
+
+  {{#each navItems as |navItem|}}
+    {{#if (shouldBeExternal navItem selectedNavItem.displayName)}}
+      {{navigation-item content=navItem filterMode=filterMode category=category classNames="external"}}
+    {{/if}}
+  {{/each}}
+
 {{else}}
 
   {{!-- Default/Desktop Version --}}

--- a/javascripts/discourse/templates/components/navigation-bar.hbs
+++ b/javascripts/discourse/templates/components/navigation-bar.hbs
@@ -6,24 +6,37 @@
       {{d-icon (if expanded "caret-down" "caret-right")}}
     </a>
   </li>
-  {{#if expanded}}
-    <ul class="drop">
-      {{#each navItems as |navItem|}}
-        {{#if (shouldBeInternal navItem selectedNavItem.displayName)}}
+  {{#if isMobile}}
+    {{#if expanded}}
+      <ul class="drop">
+        {{#each navItems as |navItem|}}
           {{navigation-item content=navItem filterMode=filterMode category=category}}
-        {{/if}}
-      {{/each}}
-      {{#each connectors as |c|}}
-        {{plugin-connector connector=c class=c.classNames tagName="li" args=(hash category=category filterMode=filterMode)}}
-      {{/each}}
-    </ul>
-  {{/if}}
-
-  {{#each navItems as |navItem|}}
-    {{#if (shouldBeExternal navItem selectedNavItem.displayName)}}
-      {{navigation-item content=navItem filterMode=filterMode category=category classNames="external"}}
+        {{/each}}
+        {{#each connectors as |c|}}
+          {{plugin-connector connector=c class=c.classNames tagName="li" args=(hash category=category filterMode=filterMode)}}
+        {{/each}}
+      </ul>
     {{/if}}
-  {{/each}}
+  {{else}}
+    {{#if expanded}}
+      <ul class="drop">
+        {{#each navItems as |navItem|}}
+          {{#if (shouldBeInternal navItem selectedNavItem.displayName)}}
+            {{navigation-item content=navItem filterMode=filterMode category=category}}
+          {{/if}}
+        {{/each}}
+        {{#each connectors as |c|}}
+          {{plugin-connector connector=c class=c.classNames tagName="li" args=(hash category=category filterMode=filterMode)}}
+        {{/each}}
+      </ul>
+    {{/if}}
+
+    {{#each navItems as |navItem|}}
+      {{#if (shouldBeExternal navItem selectedNavItem.displayName)}}
+        {{navigation-item content=navItem filterMode=filterMode category=category classNames="external"}}
+      {{/if}}
+    {{/each}}
+  {{/if}}
 
 {{else}}
 

--- a/settings.yml
+++ b/settings.yml
@@ -10,3 +10,7 @@ on_category_pages:
   type: bool
   default: false
   description: "Show minimal nav on category pages"
+nav_items_to_exclude:
+  type: list
+  default: ""
+  description: "A list of nav item names to exclude from the 'compact' nav, and keep in the nav pills list."


### PR DESCRIPTION
This commit adds the ability (via settings) to exclude certain items from the compact nav, having them appear as normal, on the side of the drop down menu.

### Before
![image](https://user-images.githubusercontent.com/30537603/103697244-3e460700-4f65-11eb-9398-d1d870dc422f.png)


### After
![image](https://user-images.githubusercontent.com/30537603/103697166-253d5600-4f65-11eb-9105-f8881b520b1e.png)

### Settings
This will be a list.
![image](https://user-images.githubusercontent.com/30537603/103698427-f88a3e00-4f66-11eb-8b92-859cbf732f25.png)

